### PR TITLE
Support for global server-side props for NextJS integration

### DIFF
--- a/integration/nextjs-scripts/lib/template/server.js
+++ b/integration/nextjs-scripts/lib/template/server.js
@@ -15,11 +15,11 @@ const Page = () => (
         : renderEmptyPage(JSON.parse('<%- emptyPageArgs %>'))
 );
 
-/** @namespace Pages/getGlobalServerSideProps */
-const getGlobalServerSideProps = () => ({ props: {} });
+/** @namespace Pages/getCommonServerSideProps */
+const getCommonServerSideProps = () => ({ props: {} });
 
 /** @namespace <%= server_namespace %> */
-const getServerSideProps = () => getGlobalServerSideProps();
+const getServerSideProps = () => getCommonServerSideProps();
 
 export { getServerSideProps };
 export default Page;


### PR DESCRIPTION
Added new `Pages/getGlobalServerSideProps` namespace to the NextJS server-side page template. The content of that namespace is the default output of `Pages/<page>/getServerSideProps` for all pages and is supposed to contain global props that are accessible by all Next pages.