### PR TITLE
fix for building the project with craco-scripts

### DIFF
--- a/integration/mosaic-cra-scripts/craco.config.js
+++ b/integration/mosaic-cra-scripts/craco.config.js
@@ -58,7 +58,8 @@ module.exports = () => {
                         {
                             // for some reason only classic works
                             // the "automatic" does not work
-                            runtime: 'classic'
+                            runtime: 'classic',
+                            absoluteRuntime: false
                         }
                     ]
                 ];


### PR DESCRIPTION
This PR fixes building the project with mosaic-cra-scripts

Apparently, it was enough just to add `absoluteRuntime: false` option to config to resolve the issue with the building.
Without this fix the build dies with the following error:
![Screenshot_20210508_134422](https://user-images.githubusercontent.com/18352350/117536407-805e8280-b003-11eb-9f79-4739adbbe879.png)
