### PR TITLE
Resolve unexpected babel behaviour

### DIFF
--- a/core/mosaic-test-utils/jest/middleware-jest-config.js
+++ b/core/mosaic-test-utils/jest/middleware-jest-config.js
@@ -14,17 +14,24 @@ const provideProperBabelTransform = (jestConfig, envType) => {
     const jsTransformKey = Object.keys(jestConfig.transform).find(
         (key) => new RegExp(key).test('sample.js')
     );
+    const nodeModulesIgnoreIndex = jestConfig.transformIgnorePatterns.findIndex(
+        (key) => key.includes('node_modules')
+    );
 
     if (!jsTransformKey) {
         throw new Error('Internal error: unable to locate JS transform');
     }
 
     jestConfig.transform[jsTransformKey] = require.resolve(`./${envType}-babel-transform`);
+
+    if (nodeModulesIgnoreIndex !== -1) {
+        jestConfig.transformIgnorePatterns[nodeModulesIgnoreIndex] = '[/\\\\]node_modules[/\\\\](?!@tilework[/\\\\]mosaic-test-utils).+\\.(js|jsx|mjs|cjs|ts|tsx)$';
+    }
 };
 
 const provideGlobals = (jestConfig) => {
     jestConfig.setupFiles.push(require.resolve('./provide-globals'));
-    jestConfig.setupFiles.push(require.resolve('./cleanup'));
+    jestConfig.setupFilesAfterEnv.push(require.resolve('./cleanup'));
 };
 
 const includeExternals = (jestConfig) => {

--- a/core/mosaic-test-utils/jest/middleware-jest-config.js
+++ b/core/mosaic-test-utils/jest/middleware-jest-config.js
@@ -14,15 +14,16 @@ const provideProperBabelTransform = (jestConfig, envType) => {
     const jsTransformKey = Object.keys(jestConfig.transform).find(
         (key) => new RegExp(key).test('sample.js')
     );
-    const nodeModulesIgnoreIndex = jestConfig.transformIgnorePatterns.findIndex(
-        (key) => key.includes('node_modules')
-    );
 
     if (!jsTransformKey) {
         throw new Error('Internal error: unable to locate JS transform');
     }
 
     jestConfig.transform[jsTransformKey] = require.resolve(`./${envType}-babel-transform`);
+
+    const nodeModulesIgnoreIndex = jestConfig.transformIgnorePatterns.findIndex(
+        (key) => key.includes('node_modules')
+    );
 
     if (nodeModulesIgnoreIndex !== -1) {
         jestConfig.transformIgnorePatterns[nodeModulesIgnoreIndex] = '[/\\\\]node_modules[/\\\\](?!@tilework[/\\\\]mosaic-test-utils).+\\.(js|jsx|mjs|cjs|ts|tsx)$';

--- a/core/mosaic-test-utils/jest/testable-paths.js
+++ b/core/mosaic-test-utils/jest/testable-paths.js
@@ -18,7 +18,7 @@ const packageJsons = [
     ...extensions
 ];
 
-const { tests: testablePackages } = getMosaicConfig(process.cwd());
+const { tests: testablePackages = [] } = getMosaicConfig(process.cwd());
 
 const testablePackagePaths = packageJsons
     .filter(({ packageName }) => testablePackages[packageName])

--- a/core/mosaic-test-utils/package.json
+++ b/core/mosaic-test-utils/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.2.6",
     "@tilework/mosaic": "0.0.3",
     "@tilework/mosaic-config-injectors": "0.0.4",
     "@tilework/mosaic-dev-utils": "0.0.4",
@@ -13,9 +14,6 @@
     "babel-jest": "26.6.3",
     "babel-preset-react-app": "10.0.0",
     "react": "17.0.1"
-  },
-  "peerDependencies": {
-    "@testing-library/react": "^11.2.6"
   },
   "publishConfig": {
     "access": "public"

--- a/sample-packages/storybook-next-app/package.json
+++ b/sample-packages/storybook-next-app/package.json
@@ -30,6 +30,6 @@
     "@storybook/addon-essentials": "^6.2.8",
     "@storybook/addon-links": "^6.2.8",
     "@storybook/react": "^6.2.8",
-    "babel-loader": "^8.2.2"
+    "babel-loader": "8.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,27 +191,6 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/core@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.0.tgz#47299ff3ec8d111b493f1a9d04bf88c04e728d88"
-  integrity sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.14.0"
-    "@babel/helper-compilation-targets" "^7.13.16"
-    "@babel/helper-module-transforms" "^7.14.0"
-    "@babel/helpers" "^7.14.0"
-    "@babel/parser" "^7.14.0"
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.14.0"
-    "@babel/types" "^7.14.0"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.1.2"
-    semver "^6.3.0"
-    source-map "^0.5.0"
-
 "@babel/generator@^7.12.1", "@babel/generator@^7.13.9":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
@@ -227,15 +206,6 @@
   integrity sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==
   dependencies:
     "@babel/types" "^7.13.16"
-    jsesc "^2.5.1"
-    source-map "^0.5.0"
-
-"@babel/generator@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.0.tgz#0f35d663506c43e4f10898fbda0d752ec75494be"
-  integrity sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==
-  dependencies:
-    "@babel/types" "^7.14.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -380,20 +350,6 @@
     "@babel/traverse" "^7.13.13"
     "@babel/types" "^7.13.14"
 
-"@babel/helper-module-transforms@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz#8fcf78be220156f22633ee204ea81f73f826a8ad"
-  integrity sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==
-  dependencies:
-    "@babel/helper-module-imports" "^7.13.12"
-    "@babel/helper-replace-supers" "^7.13.12"
-    "@babel/helper-simple-access" "^7.13.12"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/helper-validator-identifier" "^7.14.0"
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.14.0"
-    "@babel/types" "^7.14.0"
-
 "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
@@ -456,11 +412,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
-"@babel/helper-validator-identifier@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
-  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
-
 "@babel/helper-validator-option@^7.12.1", "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
@@ -494,15 +445,6 @@
     "@babel/traverse" "^7.13.17"
     "@babel/types" "^7.13.17"
 
-"@babel/helpers@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.0.tgz#ea9b6be9478a13d6f961dbb5f36bf75e2f3b8f62"
-  integrity sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==
-  dependencies:
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.14.0"
-    "@babel/types" "^7.14.0"
-
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
@@ -526,11 +468,6 @@
   version "7.13.15"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.15.tgz#8e66775fb523599acb6a289e12929fa5ab0954d8"
   integrity sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==
-
-"@babel/parser@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.0.tgz#2f0ebfed92bcddcc8395b91f1895191ce2760380"
-  integrity sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -1607,20 +1544,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.0.tgz#cea0dc8ae7e2b1dec65f512f39f3483e8cc95aef"
-  integrity sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.14.0"
-    "@babel/helper-function-name" "^7.12.13"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.14.0"
-    "@babel/types" "^7.14.0"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
 "@babel/types@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
@@ -1645,14 +1568,6 @@
   integrity sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.0.tgz#3fc3fc74e0cdad878182e5f66cc6bcab1915a802"
-  integrity sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.0":
@@ -3940,7 +3855,7 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^11.1.0":
+"@testing-library/react@^11.1.0", "@testing-library/react@^11.2.6":
   version "11.2.6"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
   integrity sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==
@@ -14145,7 +14060,7 @@ parent-module@^1.0.0:
     "@types/node" "^12.0.0"
     "@types/react" "^17.0.0"
     "@types/react-dom" "^17.0.0"
-    parent-extension "file:../../Library/Caches/Yarn/v5/npm-parent-ts-react-app-0.1.2-cb7c700d-3283-4174-9068-fc40e8545a1d-1620048899274/node_modules/parent-ts-react-app/packages/parent-extension"
+    parent-extension "file:../../Library/Caches/Yarn/v6/npm-parent-ts-react-app-0.1.2-86e913e9-40e3-4219-942d-522c465fb422-1620654080955/node_modules/parent-ts-react-app/packages/parent-extension"
     react "^17.0.1"
     react-dom "^17.0.1"
     react-scripts "4.0.3"


### PR DESCRIPTION
When the Mosaic package is installed as an NPM package, Babel would incorrectly ignore the mosaic directory and would not transpile any code. As a result, `nextjs-scripts test` would throw a series of errors and won't allow for any tests to run. This pull request resolves this issue as well as fixes native Mosaic tests.