### PR TITLE
Modify ScandiPWA & Craco Architecture due to Storybook support

### DIFF
--- a/core/mosaic-craco/lib/config.js
+++ b/core/mosaic-craco/lib/config.js
@@ -4,6 +4,8 @@ const { log } = require("./logger");
 const { applyCracoConfigPlugins } = require("./features/plugins");
 const { POSTCSS_MODES } = require("./features/webpack/style/postcss");
 const { ESLINT_MODES } = require("./features/webpack/eslint");
+const { overrideCraPaths } = require("./features/cra-paths/override");
+const { getCraPaths } = require("./cra");
 
 const DEFAULT_CONFIG = {
     reactScriptsVersion: "react-scripts",
@@ -35,9 +37,17 @@ function ensureConfigSanity(cracoConfig) {
 
 function processCracoConfig(cracoConfig, context) {
     let resultingCracoConfig = deepMergeWithArray({}, DEFAULT_CONFIG, cracoConfig);
+    
     ensureConfigSanity(resultingCracoConfig);
+    applyCracoConfigPlugins(resultingCracoConfig, context);
+    processCracoPaths(resultingCracoConfig, context);
 
-    return applyCracoConfigPlugins(resultingCracoConfig, context);
+    return resultingCracoConfig;
+}
+
+function processCracoPaths(cracoConfig, context) {
+    context.paths = getCraPaths(cracoConfig);
+    overrideCraPaths(cracoConfig, context);
 }
 
 function getConfigAsObject(context) {

--- a/core/mosaic-craco/scripts/build.js
+++ b/core/mosaic-craco/scripts/build.js
@@ -1,29 +1,17 @@
 process.env.NODE_ENV = "production";
 
-const { findArgsFromCli } = require("../lib/args");
-
-// Make sure this is called before "paths" is imported.
-findArgsFromCli();
-
-const { log } = require("../lib/logger");
-const { getCraPaths, build } = require("../lib/cra");
-const { loadCracoConfigAsync } = require("../lib/config");
 const { overrideWebpackProd } = require("../lib/features/webpack/override");
-const { overrideCraPaths } = require("../lib/features/cra-paths/override");
 const { validateCraVersion } = require("../lib/validate-cra-version");
+const { build } = require("../lib/cra");
+const { initialize } = require("./script");
 
-log("Override started with arguments: ", process.argv);
-log("For environment: ", process.env.NODE_ENV);
+const { craco, context } = initialize();
 
-const context = {
-    env: process.env.NODE_ENV
-};
+craco.then(
+    (cracoConfig) => {
+        validateCraVersion(cracoConfig);
 
-loadCracoConfigAsync(context).then(cracoConfig => {
-    validateCraVersion(cracoConfig);
-
-    context.paths = getCraPaths(cracoConfig);
-    overrideCraPaths(cracoConfig, context);
-    overrideWebpackProd(cracoConfig, context);
-    build(cracoConfig);
-});
+        overrideWebpackProd(cracoConfig, context);
+        build(cracoConfig);
+    }
+);

--- a/core/mosaic-craco/scripts/script.js
+++ b/core/mosaic-craco/scripts/script.js
@@ -1,0 +1,25 @@
+const { findArgsFromCli } = require("../lib/args");
+
+// Make sure this is called before "paths" is imported.
+findArgsFromCli();
+
+const { log } = require("../lib/logger");
+const { loadCracoConfigAsync } = require("../lib/config");
+
+const initialize = () => {
+    log("Override started with arguments: ", process.argv);
+    log("For environment: ", process.env.NODE_ENV);
+
+    const context = {
+        env: process.env.NODE_ENV
+    };
+
+    const craco = loadCracoConfigAsync(context);
+
+    return {
+        craco,
+        context
+    };
+};
+
+module.exports = { initialize };

--- a/core/mosaic-craco/scripts/start.js
+++ b/core/mosaic-craco/scripts/start.js
@@ -1,33 +1,16 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "development";
 
-const { findArgsFromCli } = require("../lib/args");
-
-// Make sure this is called before "paths" is imported.
-findArgsFromCli();
-
-const { log } = require("../lib/logger");
-const { getCraPaths, start } = require("../lib/cra");
-const { loadCracoConfigAsync } = require("../lib/config");
 const { overrideWebpackDev } = require("../lib/features/webpack/override");
 const { overrideDevServer } = require("../lib/features/dev-server/override");
-const { overrideCraPaths } = require("../lib/features/cra-paths/override");
-const { validateCraVersion } = require("../lib/validate-cra-version");
+const { start } = require("../lib/cra");
+const { initialize } = require("./script");
 
-log("Override started with arguments: ", process.argv);
-log("For environment: ", process.env.NODE_ENV);
+const { craco, context } = initialize();
 
-const context = {
-    env: process.env.NODE_ENV
-};
-
-
-loadCracoConfigAsync(context).then(cracoConfig => {
-    validateCraVersion(cracoConfig);
-
-    context.paths = getCraPaths(cracoConfig);
-    overrideCraPaths(cracoConfig, context);
-    overrideWebpackDev(cracoConfig, context);
-    overrideDevServer(cracoConfig, context);
-
-    start(cracoConfig);
-});
+craco.then(
+    (cracoConfig) => {
+        overrideWebpackDev(cracoConfig, context);
+        overrideDevServer(cracoConfig, context);
+        start(cracoConfig);
+    }
+);

--- a/core/mosaic-craco/scripts/test.js
+++ b/core/mosaic-craco/scripts/test.js
@@ -1,29 +1,19 @@
 /* eslint-disable jest/no-disabled-tests */
 process.env.NODE_ENV = process.env.NODE_ENV || "test";
 
-const { findArgsFromCli } = require("../lib/args");
-
-// Make sure this is called before "paths" is imported.
-findArgsFromCli();
-
-const { log } = require("../lib/logger");
-const { getCraPaths, test } = require("../lib/cra");
-const { overrideCraPaths } = require("../lib/features/cra-paths/override");
-const { overrideJest } = require("../lib/features/jest/override");
-const { loadCracoConfigAsync } = require("../lib/config");
+const { test } = require("../lib/cra");
 const { validateCraVersion } = require("../lib/validate-cra-version");
 
-log("Override started with arguments: ", process.argv);
-log("For environment: ", process.env.NODE_ENV);
+const { overrideJest } = require("../lib/features/jest/override");
+const { initialize } = require("./script");
 
-const context = {
-    env: process.env.NODE_ENV
-};
-loadCracoConfigAsync(context).then(cracoConfig => {
-    validateCraVersion(cracoConfig);
+const { craco, context } = initialize();
 
-    context.paths = getCraPaths(cracoConfig);
-    overrideCraPaths(cracoConfig, context);
-    overrideJest(cracoConfig, context);
-    test(cracoConfig);
-});
+craco.then(
+    (cracoConfig) => {
+        validateCraVersion(cracoConfig);
+
+        overrideJest(cracoConfig, context);
+        test(cracoConfig);
+    }
+);


### PR DESCRIPTION
## What?

I've been working on adding a support for ScandiPWA and Storybook. Since ScandiPWA using craco — I want to slightly change the architecture of the scripts inside it to keep the code base up-to-date and easy to maintain.

## Why?

A change in the architecture of the code will keep the code base updated and ready for further development. 

All the changes are following the encapsulation principle. Due to this — it allows to keep the existing code base architecture extensible and easy to manage.

The storybook plugin will be much cleaner and more robust around future changes using this extensible architecture.

## How?

This includes creating an additional script that acts as a base for the main scripts to start, build, and test the application.

By separating a common part of the code to another file and making it executable before each listed script above runs — I'm following the DRY principle which helps to keep the code lightweight, reduce the repetitions and increase performance.

## Testing?

I want to make sure that my changes doesn't break any existing support for different extensions that are using it and also that the changes works in a way of improving the code base and not damaging it in the same time.

According to the CONTRIBUTING.md file testing react-app and parent-ts-react-app still works after the applied changes:

react-app:
<img width="1552" alt="Screen Shot 2021-07-09 at 15 09 03" src="https://user-images.githubusercontent.com/87139769/125084061-c7372a00-e0d1-11eb-9e77-076c3df61263.png">

parent-ts:
<img width="1552" alt="Screen Shot 2021-07-09 at 15 12 32" src="https://user-images.githubusercontent.com/87139769/125084158-e0d87180-e0d1-11eb-8588-d6c773dc4187.png">

