### PR TITLE
set default value in preparePackageName packageName argument

### DIFF
--- a/core/eslint-plugin-mosaic/lib/rules/use-namespace.js
+++ b/core/eslint-plugin-mosaic/lib/rules/use-namespace.js
@@ -143,7 +143,7 @@ const prepareFilePath = (pathname) => {
         .filter(x => !!x);
 };
 
-const preparePackageName = (packageName) => {
+const preparePackageName = (packageName = '') => {
     // This is on purpose not a path.sep (windows support)
     const [org = '', name = ''] = packageName.split('/');
 


### PR DESCRIPTION
This simple fix resolves the issue when namespace cannot be generated and prevent throwing an internal eslint error.