### PR TITLE
fix babel plugins injection if they are already preset

### DIFF
--- a/integration/mosaic-config-injectors/lib/babel/add-plugins.js
+++ b/integration/mosaic-config-injectors/lib/babel/add-plugins.js
@@ -12,14 +12,10 @@ const addBabelPlugins = (babelConfig) => {
         // This provides @namespace comments
         require.resolve(middlewareDecorator),
 
-        ...[arrowFunctionsTransformer, asyncGeneratorTransformer].filter((plugin) => {
+        ...[arrowFunctionsTransformer, asyncGeneratorTransformer]
+            .map((plugin) => require.resolve(plugin))
             // If already present in plugin list -> prevent duplicates
-            if (babelConfig.plugins.indexOf(plugin) >= 0) {
-                return false;
-            }
-
-            return true;
-        }).map((plugin) => require.resolve(plugin))
+            .filter((plugin) => !babelConfig.plugins.includes(plugin))
     ];
 
     // It's important that these plugins go before all of the other ones


### PR DESCRIPTION
This PR will fix babel plugins injection if they are already present, preventing plugin duplication error during build time