### PR TITLE
Craco Config Path Fix

### DIFF
--- a/core/mosaic-craco/scripts/build.js
+++ b/core/mosaic-craco/scripts/build.js
@@ -1,9 +1,10 @@
 process.env.NODE_ENV = "production";
 
+// This MUST be imported first
+const { initialize } = require("./script");
 const { overrideWebpackProd } = require("../lib/features/webpack/override");
 const { validateCraVersion } = require("../lib/validate-cra-version");
 const { build } = require("../lib/cra");
-const { initialize } = require("./script");
 
 const { craco, context } = initialize();
 

--- a/core/mosaic-craco/scripts/start.js
+++ b/core/mosaic-craco/scripts/start.js
@@ -1,9 +1,10 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "development";
 
+// This MUST be imported first
+const { initialize } = require("./script");
 const { overrideWebpackDev } = require("../lib/features/webpack/override");
 const { overrideDevServer } = require("../lib/features/dev-server/override");
 const { start } = require("../lib/cra");
-const { initialize } = require("./script");
 
 const { craco, context } = initialize();
 

--- a/core/mosaic-craco/scripts/test.js
+++ b/core/mosaic-craco/scripts/test.js
@@ -1,11 +1,12 @@
 /* eslint-disable jest/no-disabled-tests */
 process.env.NODE_ENV = process.env.NODE_ENV || "test";
 
+// This MUST be imported first
+const { initialize } = require("./script");
 const { test } = require("../lib/cra");
 const { validateCraVersion } = require("../lib/validate-cra-version");
 
 const { overrideJest } = require("../lib/features/jest/override");
-const { initialize } = require("./script");
 
 const { craco, context } = initialize();
 


### PR DESCRIPTION
On CSA start or build there is an error `The argument 'id' must be a non-empty string. Received ''`.
This is happening because the script is trying to lookup the craco config in project root, not in the node_modules.
The correct craco config path is passed to script as arguments.
Moved initialize script to the top in order to correctly resolve arguments.