### PR TITLE
Fixed use-namespace rule

### DIFF
--- a/core/eslint-plugin-mosaic/package.json
+++ b/core/eslint-plugin-mosaic/package.json
@@ -13,6 +13,7 @@
         "test": "mocha tests --recursive"
     },
     "dependencies": {
+        "@tilework/mosaic-dev-utils": "^0.1.6",
         "eslint-traverse": "^1.0.0",
         "requireindex": "~1.1.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14140,7 +14140,7 @@ parent-module@^1.0.0:
     "@types/node" "^12.0.0"
     "@types/react" "^17.0.0"
     "@types/react-dom" "^17.0.0"
-    parent-extension "file:../../Library/Caches/Yarn/v4/npm-parent-ts-react-app-0.2.0-f6930b41-4ef2-479f-950c-e8e52601fe6c-1626261981277/node_modules/parent-ts-react-app/packages/parent-extension"
+    parent-extension "file:../../../.cache/yarn/v4/npm-parent-ts-react-app-0.2.0-7016304a-1c74-4395-8956-cf1f72745d0c-1631749526470/node_modules/parent-ts-react-app/packages/parent-extension"
     react "^17.0.1"
     react-dom "^17.0.1"
     react-scripts "4.0.3"


### PR DESCRIPTION
Use-namespace eslint rule
1. Ignored exported functions if they aren't arrow functions.
2. Ignored finally block of promise handlers.
3. Created non-unique namespaces for promise handlers.
