### PR TITLE
fix babel inject of aliases

### DIFF
--- a/integration/mosaic-config-injectors/lib/babel/add-aliases.js
+++ b/integration/mosaic-config-injectors/lib/babel/add-aliases.js
@@ -1,18 +1,49 @@
 const { alias } = require('./util/alias');
 
+const hasPlugin = (pluginName) => (plugin) => {
+    if (Array.isArray(plugin)) {
+        return plugin[0] === pluginName;
+    }
+
+    if (typeof plugin === 'string') {
+        return plugin === pluginName;
+    }
+};
+
+const babelPluginModuleResolverResolvedPath = require.resolve('babel-plugin-module-resolver');
+const babelPluginModuleResolverWithConfig = [
+    babelPluginModuleResolverResolvedPath,
+    {
+        root: 'src',
+        loglevel: 'silent',
+        alias
+    }
+];
+
 const addAliases = (babelConfig) => {
     if (!babelConfig.plugins) {
         babelConfig.plugins = [];
     }
 
-    babelConfig.plugins.push([
-        require.resolve('babel-plugin-module-resolver'), 
-        {
-            root: 'src',
-            loglevel: 'silent',
-            alias
+    if (babelConfig.plugins.some(hasPlugin(babelPluginModuleResolverResolvedPath))) {
+        const babelPluginModuleResolver = babelConfig.plugins.find(hasPlugin(require.resolve));
+
+        if (Array.isArray(babelPluginModuleResolver)) {
+            const options = babelPluginModuleResolver[1];
+
+            options.alias = {
+                ...options.alias,
+                ...alias
+            };
+        } else if (typeof babelPluginModuleResolver === 'string') {
+            babelConfig.plugins = babelConfig.plugins.filter((plugin => !hasPlugin(babelPluginModuleResolverResolvedPath)(plugin)));
+
+            babelConfig.plugins.push(babelPluginModuleResolverWithConfig);
         }
-    ]);
+    } else {
+        babelConfig.plugins.push(babelPluginModuleResolverWithConfig);
+    }
+
 
     return babelConfig;
 };

--- a/integration/mosaic-config-injectors/lib/babel/add-aliases.js
+++ b/integration/mosaic-config-injectors/lib/babel/add-aliases.js
@@ -26,7 +26,7 @@ const addAliases = (babelConfig) => {
     }
 
     if (babelConfig.plugins.some(hasPlugin(babelPluginModuleResolverResolvedPath))) {
-        const babelPluginModuleResolver = babelConfig.plugins.find(hasPlugin(require.resolve));
+        const babelPluginModuleResolver = babelConfig.plugins.find(hasPlugin(babelPluginModuleResolverResolvedPath));
 
         if (Array.isArray(babelPluginModuleResolver)) {
             const options = babelPluginModuleResolver[1];


### PR DESCRIPTION
This fix is aimed to resolve issues when you inject config with injectWebpackConfig and injectBabelConfig together. (In [docs](https://docs.mosaic.js.org/getting-started/webpack#inject-the-configuration) tab "With initial Babel")

Resolves this:
![Screenshot_20210929_135204](https://user-images.githubusercontent.com/18352350/135255048-10099b27-a72d-47b6-96ec-da36cfd223e5.png)